### PR TITLE
Enrich slash-topics: Capsules, operator taxonomy, and initial schemas (v0.1)

### DIFF
--- a/docs/BlekkoMechanics.md
+++ b/docs/BlekkoMechanics.md
@@ -1,0 +1,66 @@
+# Blekko mechanics we inherit (and harden)
+
+This document records the operational mechanics we want from the blekko lineage, while explicitly upgrading the missing organs: provenance, governance, and replay.
+
+## 1) Slash-in / slash-out
+
+Blekko’s core move was making scope *syntactic*:
+- **slash-in** = constrain into an explicit scope (topic directory)
+- **slash-out** = exclude noise and adversarial sources
+
+In this repo:
+- slash topics -> governed scopes
+- capsules -> executable pipelines over those scopes
+
+## 2) Operators vs inspection tools vs integrations
+
+We must separate three conceptually different things that blekko visually colocated.
+
+1) **Operators** (deterministic transforms)
+- filter, sort, time-window, dedupe
+- should be `pure` by default
+
+2) **Inspection tools** (diagnostics)
+- show evidence about domains/URLs (link graphs, duplicates, cache snapshots)
+- can be pure if computed locally, or `connector` if it consults external systems
+
+3) **Integrations** (calls out of the trust boundary)
+- any external system interaction must be explicit and policy-gated
+
+The operator spec must declare which class it is (and its effect surface).
+
+## 3) Full name and resolution behavior
+
+Blekko effectively used a stable canonical name under the hood while allowing short names in the UI.
+
+We standardize:
+- **full name**: `/namespace/slug`
+- **short name**: `/slug` (resolved via follow defaults)
+
+Resolution MUST be deterministic and explainable.
+
+## 4) Private-by-default and promotion
+
+Blekko’s default privacy simplified distribution.
+
+In a governed commons:
+- everything begins private unless explicitly promoted
+- promotion is a signed act with policies and receipts
+- revocation must be modeled (no silent deletion)
+
+## 5) Auto-application behavior
+
+Blekko sometimes applied scopes automatically.
+
+In a governed system, auto-application is a *planner decision* that must emit a trace:
+- which scope/capsule was applied
+- why
+- what fallback happened if results were sparse
+
+## 6) Acceptance gate
+
+We have captured blekko mechanics sufficiently when:
+- slash-in/out is modeled via operator families and type signatures
+- resolution rules are explicit
+- promotion and revocation semantics exist
+- auto-application decisions emit trace outputs

--- a/docs/Capsules.md
+++ b/docs/Capsules.md
@@ -1,0 +1,70 @@
+# Capsules (Slash Topic Capsules)
+
+This project treats **slash topics** as governed scopes for search and knowledge surfaces.
+
+A **Capsule** is the *executable* form of a slash topic: a signed, versioned, replayable pipeline that transforms a query and/or a carrier set into artifacts (ranked results, dossiers, alerts, exports), emitting deterministic receipts.
+
+Capsules are the modern continuation of the blekko pattern:
+- **slash in**: explicit scoping and selectors
+- **slash out**: filters that remove noise and adversarial sources
+- **inspection tools**: explainable diagnostics on domains/URLs
+- **composters**: operators that turn retrieval into knowledge production
+
+## Why “Capsule”
+
+We avoid overloaded naming that creates semantic collisions. “Capsule” is neutral and maps well to: signed bundle + deterministic execution + replay.
+
+## Capsule object model (v0.1)
+
+A capsule is a **pack artifact** (content-addressed) containing:
+
+1. `capsule.manifest.json`
+   - id, version, namespace, signing keys
+   - input types and output types
+   - operator chain (pure/connector/sensitive)
+   - policy requirements and membrane expectations
+   - conformance vectors
+
+2. `operators/`
+   - operator specs (schemas + effect system)
+
+3. `fixtures/`
+   - golden inputs and expected outputs (hashes)
+
+4. `policy/`
+   - default membrane pack references and gates
+
+## Execution semantics (normative)
+
+1. A capsule MUST declare an operator chain.
+2. Each operator MUST declare its effect surface:
+   - `pure` (deterministic)
+   - `connector` (network egress)
+   - `sensitive` (touches private corpus)
+   - `publish` (user-visible / irreversible)
+3. Any `connector` or `sensitive` operator MUST sit behind a membrane rule that:
+   - allows/denies the call
+   - budgets calls/bytes
+   - emits a decision receipt
+4. Capsule outputs MUST include a receipt binding:
+   - inputs (carrier refs, topic pack refs)
+   - policy snapshot ref
+   - operator chain digest
+   - output artifact refs
+
+## Relationship to topic packs
+
+Topic packs define *meaning and scope*. Capsules define *execution over that scope*.
+
+A capsule may:
+- load one or more topic packs (e.g., `/science`, `/gov`, `/trusted-news`)
+- apply deterministic operators
+- call external search/ingest edges explicitly (never silently)
+
+## Acceptance gate (v0.1)
+
+A capsule is v0.1-compliant when:
+- it is signed
+- it is content-addressed
+- it can be replayed over a fixed carrier log
+- it emits an execution receipt that includes topic pack refs + policy snapshot

--- a/docs/ExternalIntegration.md
+++ b/docs/ExternalIntegration.md
@@ -1,0 +1,10 @@
+# External integration (governance note)
+
+Some capsule pipelines will interact with systems that are not part of the local runtime.
+
+Governance expectations:
+- such interactions are declared in the capsule manifest
+- policy decisions are recorded
+- outputs include provenance links so that replay can explain what influenced results
+
+This repository defines the governance and specification surface; concrete runtime integrations live elsewhere.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,24 @@
+# Index
+
+This repository defines governed scopes (slash topics) and their executable form (capsules).
+
+## Reading order
+
+1. `README.md`
+2. `HISTORY.md`
+3. `docs/SlashTopics.md`
+4. `docs/Capsules.md`
+5. `docs/OperatorTaxonomy.md`
+6. `docs/BlekkoMechanics.md`
+7. `docs/ResolutionRules.md`
+
+## Spec surface
+
+- Capsule manifest schema: `spec/capsule/capsule.manifest.schema.v0.1.json`
+- Operator spec schema: `spec/operators/operator.schema.v0.1.json`
+- Typed query schema: `spec/query/query.request.schema.v0.1.json`
+- Candidate set schema: `spec/results/search.resultset.schema.v0.1.json`
+
+## Fixtures
+
+Reference fixtures live under `fixtures/` and are intended to become golden vectors for conformance tests.

--- a/docs/OperatorTaxonomy.md
+++ b/docs/OperatorTaxonomy.md
@@ -1,0 +1,80 @@
+# Operator taxonomy (v0.1)
+
+Slash topics revive blekko-style explicit scoping, but the platform must distinguish four operator families.
+
+## 1) Filters (slash-out)
+
+Reduce candidate sets.
+
+Examples:
+- `/out:domain=example.com`
+- `/out:regex=...`
+- `/out:lang=en`
+- `/out:trust<0.6`
+
+Norms:
+- Filter operators SHOULD be pure/deterministic.
+- Filters MUST emit an explanation record when they remove results that would otherwise rank in top-K.
+
+## 2) Selectors (slash-in)
+
+Whitelist or constrain to explicit sets.
+
+Examples:
+- `/in:domain=*.gov`
+- `/in:source=trusted`
+- `/in:collection=/commons/science`
+
+Norms:
+- Selectors SHOULD be pure/deterministic.
+- Selector packs SHOULD be signable allowlists.
+
+## 3) Aggregators (merge + dedupe + rerank)
+
+Combine multiple corpora/engines and resolve conflicts.
+
+Examples:
+- metasearch merge
+- cross-index merge (local index + web)
+- entity-level dedupe
+
+Norms:
+- Aggregators MUST emit `DecisionTrace` describing:
+  - sources consulted
+  - dedupe decisions
+  - rerank features
+  - thresholds and backoff behavior
+
+## 4) Composters (knowledge production)
+
+Transform retrieval output into new durable artifacts.
+
+Examples:
+- dossier builder
+- evidence bundle compiler
+- claim extraction
+- entity graph emission
+- RSS/feed export
+
+Norms:
+- Composters MUST emit artifact refs and receipts.
+- Composters MUST preserve parent refs (provenance).
+
+## Effect system (required)
+
+Each operator declares exactly one primary effect surface:
+- `pure`
+- `connector`
+- `sensitive`
+- `publish`
+
+Any non-`pure` operator MUST run behind membrane policy gates.
+
+## Acceptance gate (v0.1)
+
+- Each operator family has at least one reference operator spec.
+- Each operator spec declares:
+  - input type
+  - output type
+  - effect surface
+  - required receipts/trace outputs

--- a/docs/ResolutionRules.md
+++ b/docs/ResolutionRules.md
@@ -1,0 +1,46 @@
+# Resolution rules (full name, short name, follows)
+
+Slash topics and capsules must resolve deterministically.
+
+## Terms
+
+- **full name**: `/namespace/slug` (canonical)
+- **short name**: `/slug` (UI convenience)
+- **follow set**: an ordered list of namespaces consulted when resolving short names
+
+## Deterministic resolution algorithm (v0.1)
+
+Given an input token `/slug`:
+
+1) If the token is already a full name (`/ns/slug`), it resolves to itself.
+
+2) Otherwise, resolution consults the follow set in order:
+- `/me/slug`
+- `/team/slug`
+- `/org/slug`
+- `/commons/slug`
+
+3) If multiple matches exist at the same precedence level, the resolver MUST:
+- prefer the highest-trust signing key per current policy, or
+- refuse resolution and require explicit full name
+
+4) If no match exists:
+- the resolver returns `unresolved` and SHOULD include suggestions (edit distance + category hints)
+
+## Audit requirements
+
+Every resolution MUST be explainable.
+
+A resolution receipt SHOULD include:
+- input token
+- resolved full name (or unresolved)
+- follow set snapshot hash
+- policy snapshot hash
+- winning pack digest and signer key ref (if resolved)
+
+## Acceptance gate (v0.1)
+
+We have resolution sufficiently specified when:
+- the algorithm is deterministic
+- ambiguity behavior is defined
+- the receipt schema can encode the decision

--- a/docs/notes_apr2026.md
+++ b/docs/notes_apr2026.md
@@ -1,0 +1,3 @@
+# Notes
+
+Placeholder notes file.

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -1,0 +1,16 @@
+# Fixtures
+
+Fixtures are golden vectors used for conformance testing.
+
+v0.1 goals:
+- validate capsule manifest schema acceptance
+- validate deterministic resolution decisions (short name -> full name) and the emitted receipt fields
+- validate operator spec schema acceptance
+- validate query/resultset schema acceptance
+
+Each fixture should include:
+- an input JSON object
+- expected output JSON object(s)
+- expected hashes (canonicalized)
+
+Fixtures are intentionally minimal in v0.1; they become strict as the runtime hardens.

--- a/spec/capsule/capsule.manifest.schema.v0.1.json
+++ b/spec/capsule/capsule.manifest.schema.v0.1.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/slash-topics/spec/capsule/capsule.manifest.schema.v0.1.json",
+  "title": "CapsuleManifest",
+  "type": "object",
+  "required": [
+    "version",
+    "capsule_id",
+    "created_at",
+    "namespace",
+    "operator_chain",
+    "inputs",
+    "outputs",
+    "policy_requirements",
+    "signing"
+  ],
+  "properties": {
+    "version": { "const": "0.1" },
+    "capsule_id": { "type": "string" },
+    "created_at": { "type": "string" },
+    "namespace": { "type": "string", "description": "E.g. /me, /org, /commons." },
+    "description": { "type": "string" },
+    "tags": { "type": "array", "items": { "type": "string" } },
+    "operator_chain": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["op_id", "effect"],
+        "properties": {
+          "op_id": { "type": "string" },
+          "version": { "type": "string" },
+          "effect": {
+            "type": "string",
+            "enum": ["pure", "connector", "sensitive", "publish"]
+          },
+          "params": { "type": "object" }
+        }
+      }
+    },
+    "inputs": {
+      "type": "object",
+      "required": ["query_types"],
+      "properties": {
+        "query_types": { "type": "array", "items": { "type": "string" } },
+        "topic_pack_refs": { "type": "array", "items": { "type": "string" } },
+        "carrier_refs": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "outputs": {
+      "type": "object",
+      "required": ["artifact_types"],
+      "properties": {
+        "artifact_types": { "type": "array", "items": { "type": "string" } },
+        "contracts": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "policy_requirements": {
+      "type": "object",
+      "required": ["membrane_pack_refs"],
+      "properties": {
+        "membrane_pack_refs": { "type": "array", "items": { "type": "string" } },
+        "gates": { "type": "array", "items": { "type": "string" } },
+        "budgets": { "type": "object" }
+      }
+    },
+    "signing": {
+      "type": "object",
+      "required": ["key_ref"],
+      "properties": {
+        "key_ref": { "type": "string" },
+        "sig_ref": { "type": "string" },
+        "algo": { "type": "string" }
+      }
+    },
+    "fixtures": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "input_ref", "expected_output_refs"],
+        "properties": {
+          "name": { "type": "string" },
+          "input_ref": { "type": "string" },
+          "expected_output_refs": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    }
+  }
+}

--- a/spec/operators/operator.schema.v0.1.json
+++ b/spec/operators/operator.schema.v0.1.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/slash-topics/spec/operators/operator.schema.v0.1.json",
+  "title": "OperatorSpec",
+  "type": "object",
+  "required": [
+    "version",
+    "op_id",
+    "family",
+    "effect",
+    "inputs",
+    "outputs",
+    "emits"
+  ],
+  "properties": {
+    "version": { "const": "0.1" },
+    "op_id": { "type": "string" },
+    "family": {
+      "type": "string",
+      "enum": ["filter", "selector", "aggregator", "composter"]
+    },
+    "effect": {
+      "type": "string",
+      "enum": ["pure", "connector", "sensitive", "publish"]
+    },
+    "description": { "type": "string" },
+    "inputs": {
+      "type": "object",
+      "properties": {
+        "query_types": { "type": "array", "items": { "type": "string" } },
+        "carrier_types": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "outputs": {
+      "type": "object",
+      "properties": {
+        "carrier_types": { "type": "array", "items": { "type": "string" } },
+        "artifact_types": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "params_schema_ref": { "type": "string" },
+    "emits": {
+      "type": "array",
+      "description": "Contracts emitted for audit/replay (e.g., DecisionTrace, MembraneDecision, CapsuleOutput).",
+      "items": { "type": "string" }
+    },
+    "budgets": {
+      "type": "object",
+      "properties": {
+        "max_calls": { "type": "integer" },
+        "max_bytes": { "type": "integer" }
+      }
+    }
+  }
+}

--- a/spec/query/query.request.schema.v0.1.json
+++ b/spec/query/query.request.schema.v0.1.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/slash-topics/spec/query/query.request.schema.v0.1.json",
+  "title": "QueryRequest",
+  "type": "object",
+  "required": ["version", "query_text", "created_at", "scope_ref", "policy_tags"],
+  "properties": {
+    "version": { "const": "0.1" },
+    "query_text": { "type": "string" },
+    "created_at": { "type": "string" },
+    "scope_ref": { "type": "string" },
+    "capsule_ref": { "type": "string" },
+    "intent": {
+      "type": "string",
+      "description": "Optional intent classifier output (news, reference, research, etc.)."
+    },
+    "constraints": {
+      "type": "object",
+      "properties": {
+        "time_range": { "type": "string" },
+        "language": { "type": "string" },
+        "region": { "type": "string" }
+      }
+    },
+    "policy_tags": {
+      "type": "object",
+      "properties": {
+        "privacy_class": { "type": "string" },
+        "retention": { "type": "string" },
+        "redistribution": { "type": "string" }
+      }
+    }
+  }
+}

--- a/spec/results/search.resultset.schema.v0.1.json
+++ b/spec/results/search.resultset.schema.v0.1.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/slash-topics/spec/results/search.resultset.schema.v0.1.json",
+  "title": "SearchResultSet",
+  "type": "object",
+  "required": ["version", "created_at", "query_ref", "hits", "provenance"],
+  "properties": {
+    "version": { "const": "0.1" },
+    "created_at": { "type": "string" },
+    "query_ref": { "type": "string" },
+    "hits": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["rank", "title", "url"],
+        "properties": {
+          "rank": { "type": "integer" },
+          "title": { "type": "string" },
+          "url": { "type": "string" },
+          "snippet": { "type": "string" },
+          "source": { "type": "string" },
+          "score": { "type": "number" }
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "properties": {
+        "provider": { "type": "string" },
+        "provider_instance": { "type": "string" },
+        "timestamp": { "type": "string" }
+      }
+    },
+    "decision_trace_ref": { "type": "string" }
+  }
+}


### PR DESCRIPTION
This PR enriches `slash-topics` with missing spec surface needed to platform governed slash topics as executable pipelines.

Added:
- `docs/Capsules.md`: capsule concept + norms (signed, content-addressed, replayable)
- `docs/OperatorTaxonomy.md`: filter/selector/aggregator/composter taxonomy + effect system
- `spec/capsule/capsule.manifest.schema.v0.1.json`: capsule manifest schema
- `spec/operators/operator.schema.v0.1.json`: operator spec schema
- `spec/query/query.request.schema.v0.1.json`: typed query request stub
- `spec/results/search.resultset.schema.v0.1.json`: resultset schema stub
- `docs/ExternalIntegration.md`: governance note for external integrations

Notes:
- We avoided renaming existing terms in this repo; these additions are additive.
- Next follow-on PR should wire conformance fixtures and an index document for new spec paths.
