### PR TITLE
Add Lattice platform asset topic pack

### DIFF
--- a/.github/workflows/lattice-platform-assets.yml
+++ b/.github/workflows/lattice-platform-assets.yml
@@ -1,0 +1,21 @@
+name: lattice-platform-assets
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate Lattice topic packs
+        run: python scripts/validate_lattice_topic_pack.py

--- a/protocols/lattice/platform-asset-topic-pack.v1.json
+++ b/protocols/lattice/platform-asset-topic-pack.v1.json
@@ -1,0 +1,27 @@
+{
+  "apiVersion": "slash-topics.socioprophet.dev/v1",
+  "kind": "SlashTopicPack",
+  "metadata": {
+    "name": "lattice-platform-assets",
+    "version": "0.1.0",
+    "description": "Governed slash-topic candidates for Prophet Lattice platform asset records."
+  },
+  "subjects": [
+    {
+      "subjectKind": "PlatformAssetRecord",
+      "match": {"assetKind": "runtime-asset"},
+      "topics": ["/lattice", "/lattice/runtime", "/lattice/forge", "/forge", "/runtime", "/supply-chain", "/policy", "/contracts", "/modeling"]
+    },
+    {
+      "subjectKind": "PlatformAssetRecord",
+      "match": {"assetKind": "boot-release-set"},
+      "topics": ["/lattice", "/lattice/boot", "/sourceos", "/sourceos/boot", "/sourceos/recovery", "/release", "/policy", "/contracts", "/modeling"]
+    }
+  ],
+  "governance": {
+    "signedPackRequired": true,
+    "replayable": true,
+    "canonicalProducer": "SocioProphet/prophet-platform",
+    "canonicalRecordKind": "PlatformAssetRecord"
+  }
+}

--- a/scripts/validate_lattice_topic_pack.py
+++ b/scripts/validate_lattice_topic_pack.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Validate Lattice platform asset slash topic packs."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def validate(path: Path) -> None:
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    require(doc.get("apiVersion") == "slash-topics.socioprophet.dev/v1", "apiVersion mismatch")
+    require(doc.get("kind") == "SlashTopicPack", "kind mismatch")
+    require(isinstance(doc.get("subjects"), list) and doc["subjects"], "subjects must be a non-empty list")
+    for subject in doc["subjects"]:
+        require(subject.get("subjectKind") == "PlatformAssetRecord", "subjectKind must be PlatformAssetRecord")
+        require(isinstance(subject.get("match"), dict), "match must be an object")
+        topics = subject.get("topics")
+        require(isinstance(topics, list) and topics, "topics must be a non-empty list")
+        for topic in topics:
+            require(isinstance(topic, str) and topic.startswith("/"), f"invalid slash topic: {topic!r}")
+    governance = doc.get("governance")
+    require(isinstance(governance, dict), "governance must be an object")
+    require(governance.get("canonicalRecordKind") == "PlatformAssetRecord", "canonicalRecordKind mismatch")
+
+
+def main(argv: list[str] | None = None) -> int:
+    paths = [Path(arg) for arg in (argv if argv is not None else sys.argv[1:])]
+    if not paths:
+        paths = sorted(Path("protocols/lattice").glob("*.json"))
+    failed = False
+    for path in paths:
+        try:
+            validate(path)
+            print(f"PASS {path}")
+        except Exception as exc:  # noqa: BLE001
+            failed = True
+            print(f"FAIL {path}: {exc}", file=sys.stderr)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a governed Slash Topics pack for Prophet Lattice platform asset records.

## What changed

- Adds `protocols/lattice/platform-asset-topic-pack.v1.json`.
- Adds validator for Lattice platform asset topic packs.
- Adds CI workflow for topic-pack validation.

## Why

Lattice platform asset records need deterministic topic candidates for Sherlock Search, New Hope membranes, Policy Fabric, ContractForge, and internal metadata classifiers. This keeps scope vocabulary shared instead of ad hoc.

## Integration

Aligns with `PlatformAssetRecord` and enrichment sidecars emitted by `prophet-platform`.
