### PR TITLE
Replay Lattice topic pack against platform enrichments

### DIFF
--- a/.github/workflows/lattice-platform-assets.yml
+++ b/.github/workflows/lattice-platform-assets.yml
@@ -20,6 +20,6 @@ jobs:
       - name: Validate Lattice topic packs
         run: python scripts/validate_lattice_topic_pack.py
       - name: Replay Lattice topic pack against platform enrichment fixture
-        run: python scripts/replay_lattice_topics.py protocols/lattice/platform-asset-topic-pack.v1.json fixtures/lattice/platform-asset-enrichment-set.example.json --output build/lattice-topic-replay.json
+        run: python scripts/replay_lattice_topics.py protocols/lattice/platform-asset-topic-pack.v1.json fixtures/lattice/platform-asset-enrichment-set.example.json --output lattice-topic-replay.json
       - name: Validate Lattice topic replay report
-        run: python scripts/validate_lattice_topic_replay.py build/lattice-topic-replay.json
+        run: python scripts/validate_lattice_topic_replay.py lattice-topic-replay.json

--- a/.github/workflows/lattice-platform-assets.yml
+++ b/.github/workflows/lattice-platform-assets.yml
@@ -19,3 +19,7 @@ jobs:
           python-version: "3.11"
       - name: Validate Lattice topic packs
         run: python scripts/validate_lattice_topic_pack.py
+      - name: Replay Lattice topic pack against platform enrichment fixture
+        run: python scripts/replay_lattice_topics.py protocols/lattice/platform-asset-topic-pack.v1.json fixtures/lattice/platform-asset-enrichment-set.example.json --output build/lattice-topic-replay.json
+      - name: Validate Lattice topic replay report
+        run: python scripts/validate_lattice_topic_replay.py build/lattice-topic-replay.json

--- a/fixtures/lattice/platform-asset-enrichment-set.example.json
+++ b/fixtures/lattice/platform-asset-enrichment-set.example.json
@@ -1,0 +1,34 @@
+{
+  "apiVersion": "prophet.socioprophet.dev/v1",
+  "kind": "PlatformAssetRecordEnrichmentSet",
+  "enrichments": [
+    {
+      "apiVersion": "prophet.socioprophet.dev/v1",
+      "kind": "PlatformAssetRecordEnrichment",
+      "assetId": "runtime-asset:prophet-python-ml:0.1.0",
+      "search": {
+        "facets": {
+          "assetKind": "runtime-asset",
+          "producerRepo": "SocioProphet/lattice-forge",
+          "promotionChannel": "dev",
+          "compatibilitySurfaces": ["jupyter", "ray", "beam", "agentplane", "sourceos-user", "prophet-platform"]
+        }
+      },
+      "slashTopics": ["/lattice", "/lattice/runtime", "/forge", "/runtime", "/supply-chain", "/policy", "/contracts", "/modeling"]
+    },
+    {
+      "apiVersion": "prophet.socioprophet.dev/v1",
+      "kind": "PlatformAssetRecordEnrichment",
+      "assetId": "boot-release-set:sourceos-recovery-demo:0.1.0",
+      "search": {
+        "facets": {
+          "assetKind": "boot-release-set",
+          "producerRepo": "SourceOS-Linux/sourceos-boot",
+          "promotionChannel": null,
+          "compatibilitySurfaces": ["sourceos-boot", "prophet-platform"]
+        }
+      },
+      "slashTopics": ["/lattice", "/lattice/boot", "/sourceos", "/sourceos/boot", "/sourceos/recovery", "/release", "/policy", "/contracts", "/modeling"]
+    }
+  ]
+}

--- a/scripts/replay_lattice_topics.py
+++ b/scripts/replay_lattice_topics.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Replay Lattice topic-pack assignments against PlatformAssetRecord enrichments."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return data
+
+
+def matches(match: dict[str, Any], facets: dict[str, Any]) -> bool:
+    return all(facets.get(key) == value for key, value in match.items())
+
+
+def replay(topic_pack: dict[str, Any], enrichment_set: dict[str, Any]) -> dict[str, Any]:
+    if topic_pack.get("kind") != "SlashTopicPack":
+        raise ValueError("topic pack kind must be SlashTopicPack")
+    if enrichment_set.get("kind") != "PlatformAssetRecordEnrichmentSet":
+        raise ValueError("enrichment set kind must be PlatformAssetRecordEnrichmentSet")
+
+    subjects = topic_pack.get("subjects")
+    enrichments = enrichment_set.get("enrichments")
+    if not isinstance(subjects, list):
+        raise ValueError("topic pack subjects must be a list")
+    if not isinstance(enrichments, list):
+        raise ValueError("enrichments must be a list")
+
+    assignments = []
+    for enrichment in enrichments:
+        if not isinstance(enrichment, dict):
+            continue
+        asset_id = enrichment.get("assetId")
+        facets = enrichment.get("search", {}).get("facets", {})
+        if not isinstance(asset_id, str) or not isinstance(facets, dict):
+            continue
+        topics: set[str] = set(enrichment.get("slashTopics", []))
+        matched_rules = []
+        for index, subject in enumerate(subjects):
+            if not isinstance(subject, dict):
+                continue
+            if subject.get("subjectKind") != "PlatformAssetRecord":
+                continue
+            match = subject.get("match", {})
+            if isinstance(match, dict) and matches(match, facets):
+                topics.update(str(topic) for topic in subject.get("topics", []))
+                matched_rules.append(index)
+        assignments.append({
+            "assetId": asset_id,
+            "matchedRules": matched_rules,
+            "topics": sorted(topic for topic in topics if isinstance(topic, str) and topic.startswith("/")),
+        })
+
+    return {
+        "apiVersion": "slash-topics.socioprophet.dev/v1",
+        "kind": "SlashTopicReplayReport",
+        "topicPack": topic_pack.get("metadata", {}).get("name"),
+        "assignments": assignments,
+    }
+
+
+def emit(report: dict[str, Any], output: Path | None) -> None:
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if output is None:
+        print(rendered, end="")
+        return
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(rendered, encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Replay Lattice Slash Topic assignments")
+    parser.add_argument("topic_pack", type=Path)
+    parser.add_argument("enrichment_set", type=Path)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        emit(replay(load_json(args.topic_pack), load_json(args.enrichment_set)), args.output)
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        print(f"replay_lattice_topics: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_lattice_topic_replay.py
+++ b/scripts/validate_lattice_topic_replay.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Validate Lattice Slash Topic replay reports."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+REQUIRED_ASSETS = {
+    "runtime-asset:prophet-python-ml:0.1.0": "/lattice/runtime",
+    "boot-release-set:sourceos-recovery-demo:0.1.0": "/lattice/boot",
+}
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def validate(path: Path) -> None:
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    require(doc.get("apiVersion") == "slash-topics.socioprophet.dev/v1", "apiVersion mismatch")
+    require(doc.get("kind") == "SlashTopicReplayReport", "kind mismatch")
+    assignments = doc.get("assignments")
+    require(isinstance(assignments, list) and assignments, "assignments must be non-empty")
+    by_asset = {item.get("assetId"): item for item in assignments if isinstance(item, dict)}
+    for asset_id, expected_topic in REQUIRED_ASSETS.items():
+        require(asset_id in by_asset, f"missing assignment for {asset_id}")
+        topics = by_asset[asset_id].get("topics")
+        require(isinstance(topics, list), f"topics for {asset_id} must be a list")
+        require(expected_topic in topics, f"{asset_id} missing expected topic {expected_topic}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    paths = [Path(arg) for arg in (argv if argv is not None else sys.argv[1:])]
+    failed = False
+    for path in paths:
+        try:
+            validate(path)
+            print(f"PASS {path}")
+        except Exception as exc:  # noqa: BLE001
+            failed = True
+            print(f"FAIL {path}: {exc}", file=sys.stderr)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds executable replay for applying the Lattice Slash Topic pack to Prophet Platform asset enrichments.

## What changed

- Adds `fixtures/lattice/platform-asset-enrichment-set.example.json`.
- Adds `scripts/replay_lattice_topics.py`.
- Adds `scripts/validate_lattice_topic_replay.py`.
- Extends CI to replay the topic pack against the enrichment fixture and validate the replay report.

## Why

The previous tranche added a static governed topic pack. This PR proves topic assignment is deterministic and executable against the same `PlatformAssetRecordEnrichmentSet` shape emitted by `prophet-platform`.

## Integration

Consumes platform enrichments and emits `SlashTopicReplayReport` assignments for Lattice boot/runtime assets.
