### PR TITLE
Classify Lattice Data/GovernAI assets as governed topic pack

### DIFF
--- a/.github/workflows/lattice-data-governai-topic-pack.yml
+++ b/.github/workflows/lattice-data-governai-topic-pack.yml
@@ -1,0 +1,27 @@
+name: lattice-data-governai-topic-pack
+
+on:
+  pull_request:
+    paths:
+      - "packs/lattice-data-governai/**"
+      - "tools/validate_lattice_data_governai_topic_pack.py"
+      - ".github/workflows/lattice-data-governai-topic-pack.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-lattice-data-governai-topic-pack:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Validate Lattice Data/GovernAI topic pack
+        run: python tools/validate_lattice_data_governai_topic_pack.py

--- a/packs/lattice-data-governai/topic-pack.v0.1.json
+++ b/packs/lattice-data-governai/topic-pack.v0.1.json
@@ -1,0 +1,103 @@
+{
+  "apiVersion": "slash-topics.socioprophet.dev/v1",
+  "kind": "TopicPack",
+  "metadata": {
+    "name": "lattice-data-governai",
+    "version": "0.1.0",
+    "description": "Governed topic pack for Lattice Studio/Data/GovernAI data, runtime, model, prompt, evaluation, factsheet, publication, Ray, and Beam assets."
+  },
+  "spec": {
+    "publicSurfaceRef": "slash-topic://lattice/data-governai",
+    "topicPackRef": "slash-topics://packs/lattice-data-governai@0.1.0",
+    "runtimeAliasRef": "slash-topics://runtime/membranes/lattice-data-governai-admission@0.1.0",
+    "compatibilityRef": "newhope://membranes/lattice-data-governai-admission@0.1.0",
+    "memoryProfileRef": "memory-mesh://profiles/slash-topic-scoped-lattice-data-governai@0.1.0",
+    "sourceRefs": {
+      "umbrellaIssue": "SocioProphet/prophet-platform#291",
+      "sherlockPr": "SocioProphet/sherlock-search#30",
+      "topologyPr": "SocioProphet/sociosphere#238",
+      "policyPr": "SocioProphet/policy-fabric#39"
+    },
+    "assetClassifications": [
+      {
+        "assetKind": "data-product",
+        "topic": "/lattice/data-product",
+        "scope": "public-discovery",
+        "governancePosture": "policy-gated-query",
+        "requiredRefs": ["policyRef", "evidenceCorrelationId", "dataLineageRefs"],
+        "consumerSurfaces": ["sherlock-search", "policy-fabric", "new-hope"]
+      },
+      {
+        "assetKind": "runtime-asset",
+        "topic": "/lattice/runtime",
+        "scope": "runtime-discovery",
+        "governancePosture": "policy-gated-launch",
+        "requiredRefs": ["policyRef", "evidenceCorrelationId", "runtimeRef"],
+        "consumerSurfaces": ["sherlock-search", "agentplane", "policy-fabric"]
+      },
+      {
+        "assetKind": "query-run",
+        "topic": "/lattice/query-run",
+        "scope": "query-evidence",
+        "governancePosture": "federated-query-record",
+        "requiredRefs": ["policyRef", "evidenceCorrelationId", "dataLineageRefs"],
+        "consumerSurfaces": ["sherlock-search", "new-hope", "policy-fabric"]
+      },
+      {
+        "assetKind": "evaluation-bundle",
+        "topic": "/lattice/governai/evaluation",
+        "scope": "governai-review",
+        "governancePosture": "review-required-when-verdict-needs-review",
+        "requiredRefs": ["policyRef", "evidenceCorrelationId", "runtimeRef"],
+        "consumerSurfaces": ["sherlock-search", "policy-fabric", "new-hope"]
+      },
+      {
+        "assetKind": "factsheet",
+        "topic": "/lattice/governai/factsheet",
+        "scope": "governai-review",
+        "governancePosture": "approval-state-visible",
+        "requiredRefs": ["evidenceCorrelationId", "dataLineageRefs"],
+        "consumerSurfaces": ["sherlock-search", "new-hope", "policy-fabric"]
+      },
+      {
+        "assetKind": "publication-artifact",
+        "topic": "/lattice/publication",
+        "scope": "reproducible-publishing",
+        "governancePosture": "review-required-before-export",
+        "requiredRefs": ["policyRef", "evidenceCorrelationId", "dataLineageRefs"],
+        "consumerSurfaces": ["sherlock-search", "policy-fabric", "new-hope"]
+      },
+      {
+        "assetKind": "ray-job-dry-run",
+        "topic": "/lattice/mlops/ray",
+        "scope": "mlops-execution-evidence",
+        "governancePosture": "dry-run-execution-evidence",
+        "requiredRefs": ["policyRef", "evidenceCorrelationId", "runtimeRef", "dataLineageRefs"],
+        "consumerSurfaces": ["sherlock-search", "agentplane", "policy-fabric"]
+      },
+      {
+        "assetKind": "beam-pipeline-dry-run",
+        "topic": "/lattice/mlops/beam",
+        "scope": "dataops-execution-evidence",
+        "governancePosture": "dry-run-execution-evidence",
+        "requiredRefs": ["policyRef", "evidenceCorrelationId", "runtimeRef", "dataLineageRefs"],
+        "consumerSurfaces": ["sherlock-search", "policy-fabric", "new-hope"]
+      }
+    ],
+    "routingRules": {
+      "requiredSequence": [
+        "slash-topic-scope",
+        "slash-topics-runtime-alias",
+        "newhope-compatibility-membrane",
+        "memory-mesh-profile",
+        "policy-fabric-decision",
+        "consumer-surface-route"
+      ],
+      "publicSurface": "slash-topics",
+      "runtimeSubstrate": "new-hope",
+      "dryRunOnly": true,
+      "mustNotBypassPolicyFabric": true,
+      "mustNotRedefinePlatformAssetRecord": true
+    }
+  }
+}

--- a/tools/validate_lattice_data_governai_topic_pack.py
+++ b/tools/validate_lattice_data_governai_topic_pack.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Validate the Lattice Data/GovernAI Slash Topics topic pack."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+PACK = ROOT / "packs" / "lattice-data-governai" / "topic-pack.v0.1.json"
+
+REQUIRED_ASSET_KINDS = {
+    "data-product",
+    "runtime-asset",
+    "query-run",
+    "evaluation-bundle",
+    "factsheet",
+    "publication-artifact",
+    "ray-job-dry-run",
+    "beam-pipeline-dry-run",
+}
+REQUIRED_SEQUENCE = [
+    "slash-topic-scope",
+    "slash-topics-runtime-alias",
+    "newhope-compatibility-membrane",
+    "memory-mesh-profile",
+    "policy-fabric-decision",
+    "consumer-surface-route",
+]
+
+
+def fail(message: str) -> int:
+    print(f"ERR: {message}", file=sys.stderr)
+    return 1
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def require_str(mapping: dict[str, Any], key: str) -> str:
+    value = mapping.get(key)
+    require(isinstance(value, str) and bool(value), f"{key} must be a non-empty string")
+    return value
+
+
+def require_list(mapping: dict[str, Any], key: str) -> list[Any]:
+    value = mapping.get(key)
+    require(isinstance(value, list) and value, f"{key} must be a non-empty list")
+    return value
+
+
+def main() -> int:
+    if not PACK.exists():
+        return fail(f"missing {PACK}")
+    try:
+        data = json.loads(PACK.read_text(encoding="utf-8"))
+        require(isinstance(data, dict), "topic pack root must be object")
+        require(data.get("apiVersion") == "slash-topics.socioprophet.dev/v1", "apiVersion mismatch")
+        require(data.get("kind") == "TopicPack", "kind must be TopicPack")
+        metadata = data.get("metadata")
+        require(isinstance(metadata, dict), "metadata must be object")
+        require(metadata.get("name") == "lattice-data-governai", "metadata.name mismatch")
+        require(metadata.get("version") == "0.1.0", "metadata.version mismatch")
+
+        spec = data.get("spec")
+        require(isinstance(spec, dict), "spec must be object")
+        require(require_str(spec, "publicSurfaceRef").startswith("slash-topic://"), "publicSurfaceRef must be slash-topic://")
+        require(require_str(spec, "topicPackRef").startswith("slash-topics://packs/"), "topicPackRef must be slash-topics pack ref")
+        require(require_str(spec, "runtimeAliasRef").startswith("slash-topics://runtime/"), "runtimeAliasRef must be Slash Topics runtime alias")
+        require(require_str(spec, "compatibilityRef").startswith("newhope://"), "compatibilityRef must preserve New Hope compatibility")
+        require(require_str(spec, "memoryProfileRef").startswith("memory-mesh://"), "memoryProfileRef must attach Memory Mesh profile")
+
+        source_refs = spec.get("sourceRefs")
+        require(isinstance(source_refs, dict), "sourceRefs must be object")
+        for key in ["umbrellaIssue", "sherlockPr", "topologyPr", "policyPr"]:
+            require_str(source_refs, key)
+
+        classifications = require_list(spec, "assetClassifications")
+        asset_kinds = set()
+        for item in classifications:
+            require(isinstance(item, dict), "assetClassifications entries must be objects")
+            asset_kind = require_str(item, "assetKind")
+            asset_kinds.add(asset_kind)
+            require(asset_kind in REQUIRED_ASSET_KINDS, f"unexpected assetKind {asset_kind}")
+            require(require_str(item, "topic").startswith("/lattice/"), f"{asset_kind} topic must be /lattice/*")
+            require_str(item, "scope")
+            require_str(item, "governancePosture")
+            required_refs = require_list(item, "requiredRefs")
+            require("evidenceCorrelationId" in required_refs, f"{asset_kind} must require evidenceCorrelationId")
+            surfaces = require_list(item, "consumerSurfaces")
+            require("sherlock-search" in surfaces or asset_kind == "runtime-asset", f"{asset_kind} should route to Sherlock or be runtime-discoverable")
+        missing = sorted(REQUIRED_ASSET_KINDS - asset_kinds)
+        require(not missing, f"missing assetKind classifications: {missing}")
+
+        rules = spec.get("routingRules")
+        require(isinstance(rules, dict), "routingRules must be object")
+        require(rules.get("requiredSequence") == REQUIRED_SEQUENCE, "routingRules.requiredSequence mismatch")
+        require(rules.get("publicSurface") == "slash-topics", "Slash Topics must remain public surface")
+        require(rules.get("runtimeSubstrate") == "new-hope", "New Hope must remain runtime substrate")
+        require(rules.get("dryRunOnly") is True, "dryRunOnly must be true")
+        require(rules.get("mustNotBypassPolicyFabric") is True, "mustNotBypassPolicyFabric must be true")
+        require(rules.get("mustNotRedefinePlatformAssetRecord") is True, "mustNotRedefinePlatformAssetRecord must be true")
+    except Exception as exc:  # noqa: BLE001
+        return fail(str(exc))
+    print(f"PASS {PACK}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a Slash Topics topic pack for Lattice Studio/Data/GovernAI assets.

## Adds

- `packs/lattice-data-governai/topic-pack.v0.1.json`
- `tools/validate_lattice_data_governai_topic_pack.py`
- `.github/workflows/lattice-data-governai-topic-pack.yml`

## Coverage

Classifies data product, runtime asset, query run, evaluation bundle, factsheet, publication artifact, Ray dry run, and Beam dry run assets.

## Boundary discipline

Preserves Slash Topics as the public query/governance surface and New Hope as the internal membrane/runtime substrate through explicit compatibility refs.

## Validation

Expected:

```bash
python tools/validate_lattice_data_governai_topic_pack.py
```

## Tracking

Closes #22.
Coordinates with SocioProphet/prophet-platform#291, SocioProphet/sherlock-search#30, and SocioProphet/new-hope#6.