### PR TITLE
Expand Lattice Data/GovernAI topic classifications

### DIFF
--- a/packs/lattice-data-governai/topic-pack.v0.1.json
+++ b/packs/lattice-data-governai/topic-pack.v0.1.json
@@ -4,7 +4,7 @@
   "metadata": {
     "name": "lattice-data-governai",
     "version": "0.1.0",
-    "description": "Governed topic pack for Lattice Studio/Data/GovernAI data, runtime, model, prompt, evaluation, factsheet, publication, Ray, and Beam assets."
+    "description": "Governed topic pack for Lattice Studio/Data/GovernAI data, runtime, model, prompt, RAG, evaluation, publication, annotation, trust, active metadata, Ray, and Beam assets."
   },
   "spec": {
     "publicSurfaceRef": "slash-topic://lattice/data-governai",
@@ -15,8 +15,15 @@
     "sourceRefs": {
       "umbrellaIssue": "SocioProphet/prophet-platform#291",
       "sherlockPr": "SocioProphet/sherlock-search#30",
+      "expandedSherlockPr": "SocioProphet/sherlock-search#31",
       "topologyPr": "SocioProphet/sociosphere#238",
-      "policyPr": "SocioProphet/policy-fabric#39"
+      "policyPr": "SocioProphet/policy-fabric#39",
+      "modelZooPr": "SocioProphet/prophet-platform#300",
+      "promptRagEvalPr": "SocioProphet/prophet-platform#301",
+      "publicationReviewPr": "SocioProphet/prophet-platform#302",
+      "annotationTrainingPr": "SocioProphet/prophet-platform#303",
+      "activeMetadataPr": "SocioProphet/prophet-platform#304",
+      "trustReputationPr": "SocioProphet/prophet-platform#305"
     },
     "assetClassifications": [
       {
@@ -82,6 +89,102 @@
         "governancePosture": "dry-run-execution-evidence",
         "requiredRefs": ["policyRef", "evidenceCorrelationId", "runtimeRef", "dataLineageRefs"],
         "consumerSurfaces": ["sherlock-search", "policy-fabric", "new-hope"]
+      },
+      {
+        "assetKind": "model-zoo-entry",
+        "topic": "/lattice/model-zoo/entry",
+        "scope": "model-discovery",
+        "governancePosture": "review-required-before-promotion",
+        "requiredRefs": ["policyRef", "evidenceCorrelationId", "runtimeRef", "dataLineageRefs"],
+        "consumerSurfaces": ["sherlock-search", "policy-fabric", "agentplane", "new-hope"]
+      },
+      {
+        "assetKind": "model-endpoint",
+        "topic": "/lattice/model-zoo/endpoint",
+        "scope": "serving-candidate",
+        "governancePosture": "dry-run-endpoint-before-serving",
+        "requiredRefs": ["policyRef", "evidenceCorrelationId", "runtimeRef"],
+        "consumerSurfaces": ["sherlock-search", "policy-fabric", "agentplane"]
+      },
+      {
+        "assetKind": "prompt-asset",
+        "topic": "/lattice/prompt-lab/prompt",
+        "scope": "prompt-discovery",
+        "governancePosture": "policy-gated-prompt-use",
+        "requiredRefs": ["policyRef", "evidenceCorrelationId", "dataLineageRefs"],
+        "consumerSurfaces": ["sherlock-search", "slash-topics", "policy-fabric", "new-hope"]
+      },
+      {
+        "assetKind": "rag-pipeline",
+        "topic": "/lattice/rag-lab/pipeline",
+        "scope": "rag-governance",
+        "governancePosture": "grounding-evaluation-required",
+        "requiredRefs": ["policyRef", "evidenceCorrelationId", "runtimeRef", "dataLineageRefs"],
+        "consumerSurfaces": ["sherlock-search", "policy-fabric", "agentplane", "new-hope"]
+      },
+      {
+        "assetKind": "vector-index",
+        "topic": "/lattice/rag-lab/vector-index",
+        "scope": "retrieval-index-discovery",
+        "governancePosture": "policy-gated-retrieval",
+        "requiredRefs": ["policyRef", "evidenceCorrelationId", "runtimeRef"],
+        "consumerSurfaces": ["sherlock-search", "policy-fabric"]
+      },
+      {
+        "assetKind": "research-package",
+        "topic": "/lattice/publication/research-package",
+        "scope": "reproducible-publishing",
+        "governancePosture": "review-required-before-publication",
+        "requiredRefs": ["policyRef", "evidenceCorrelationId", "dataLineageRefs"],
+        "consumerSurfaces": ["sherlock-search", "slash-topics", "policy-fabric", "new-hope"]
+      },
+      {
+        "assetKind": "training-dataset",
+        "topic": "/lattice/training/dataset",
+        "scope": "training-data-governance",
+        "governancePosture": "training-use-policy-required",
+        "requiredRefs": ["policyRef", "evidenceCorrelationId", "runtimeRef", "dataLineageRefs"],
+        "consumerSurfaces": ["sherlock-search", "model-zoo", "ray", "policy-fabric"]
+      },
+      {
+        "assetKind": "evaluation-dataset",
+        "topic": "/lattice/evaluation/dataset",
+        "scope": "evaluation-data-governance",
+        "governancePosture": "evaluation-use-policy-required",
+        "requiredRefs": ["policyRef", "evidenceCorrelationId", "runtimeRef", "dataLineageRefs"],
+        "consumerSurfaces": ["sherlock-search", "governai", "policy-fabric", "new-hope"]
+      },
+      {
+        "assetKind": "annotation-reliability-score",
+        "topic": "/lattice/annotation/reliability",
+        "scope": "annotation-governance",
+        "governancePosture": "reliability-score-visible",
+        "requiredRefs": ["policyRef", "evidenceCorrelationId", "dataLineageRefs"],
+        "consumerSurfaces": ["sherlock-search", "governai", "policy-fabric"]
+      },
+      {
+        "assetKind": "active-metadata-event",
+        "topic": "/lattice/active-metadata/event",
+        "scope": "metadata-ingestion",
+        "governancePosture": "event-derived-metadata-only",
+        "requiredRefs": ["policyRef", "evidenceCorrelationId", "dataLineageRefs"],
+        "consumerSurfaces": ["sherlock-search", "slash-topics", "policy-fabric", "new-hope"]
+      },
+      {
+        "assetKind": "trust-posture-summary",
+        "topic": "/lattice/trust/posture",
+        "scope": "trust-governance",
+        "governancePosture": "promotion-risk-visible",
+        "requiredRefs": ["policyRef", "evidenceCorrelationId", "dataLineageRefs"],
+        "consumerSurfaces": ["sherlock-search", "slash-topics", "policy-fabric", "new-hope"]
+      },
+      {
+        "assetKind": "trust-signal",
+        "topic": "/lattice/trust/signal",
+        "scope": "trust-governance",
+        "governancePosture": "evidence-backed-score",
+        "requiredRefs": ["policyRef", "evidenceCorrelationId", "dataLineageRefs"],
+        "consumerSurfaces": ["sherlock-search", "governai", "policy-fabric", "new-hope"]
       }
     ],
     "routingRules": {

--- a/tools/validate_lattice_data_governai_topic_pack.py
+++ b/tools/validate_lattice_data_governai_topic_pack.py
@@ -20,6 +20,18 @@ REQUIRED_ASSET_KINDS = {
     "publication-artifact",
     "ray-job-dry-run",
     "beam-pipeline-dry-run",
+    "model-zoo-entry",
+    "model-endpoint",
+    "prompt-asset",
+    "rag-pipeline",
+    "vector-index",
+    "research-package",
+    "training-dataset",
+    "evaluation-dataset",
+    "annotation-reliability-score",
+    "active-metadata-event",
+    "trust-posture-summary",
+    "trust-signal",
 }
 REQUIRED_SEQUENCE = [
     "slash-topic-scope",
@@ -29,6 +41,19 @@ REQUIRED_SEQUENCE = [
     "policy-fabric-decision",
     "consumer-surface-route",
 ]
+REQUIRED_SOURCE_REFS = {
+    "umbrellaIssue",
+    "sherlockPr",
+    "expandedSherlockPr",
+    "topologyPr",
+    "policyPr",
+    "modelZooPr",
+    "promptRagEvalPr",
+    "publicationReviewPr",
+    "annotationTrainingPr",
+    "activeMetadataPr",
+    "trustReputationPr",
+}
 
 
 def fail(message: str) -> int:
@@ -76,8 +101,8 @@ def main() -> int:
 
         source_refs = spec.get("sourceRefs")
         require(isinstance(source_refs, dict), "sourceRefs must be object")
-        for key in ["umbrellaIssue", "sherlockPr", "topologyPr", "policyPr"]:
-            require_str(source_refs, key)
+        missing_source_refs = sorted(REQUIRED_SOURCE_REFS - set(source_refs))
+        require(not missing_source_refs, f"missing sourceRefs: {missing_source_refs}")
 
         classifications = require_list(spec, "assetClassifications")
         asset_kinds = set()
@@ -92,7 +117,10 @@ def main() -> int:
             required_refs = require_list(item, "requiredRefs")
             require("evidenceCorrelationId" in required_refs, f"{asset_kind} must require evidenceCorrelationId")
             surfaces = require_list(item, "consumerSurfaces")
-            require("sherlock-search" in surfaces or asset_kind == "runtime-asset", f"{asset_kind} should route to Sherlock or be runtime-discoverable")
+            require(
+                "sherlock-search" in surfaces or asset_kind == "runtime-asset",
+                f"{asset_kind} should route to Sherlock or be runtime-discoverable",
+            )
         missing = sorted(REQUIRED_ASSET_KINDS - asset_kinds)
         require(not missing, f"missing assetKind classifications: {missing}")
 


### PR DESCRIPTION
## Summary

Expands the Lattice Data/GovernAI Slash Topics topic pack to cover the later product surfaces landed in Prophet Platform and Sherlock.

## Adds classification coverage for

- Model Zoo entries and endpoints
- Prompt assets
- RAG pipelines
- Vector indexes
- Research packages
- Training and evaluation datasets
- Annotation reliability scores
- Active metadata events
- Trust posture summaries
- Trust signals

## Boundary discipline

Keeps Slash Topics as the public query/governance surface and New Hope as the runtime substrate through the existing compatibility refs.

## Validation

Expected:

```bash
python tools/validate_lattice_data_governai_topic_pack.py
```

## Tracking

Advances SocioProphet/prophet-platform#291 and follows SocioProphet/sherlock-search#31.