### PR TITLE
Add Lattice replay evidence topic pack

### DIFF
--- a/.github/workflows/lattice-replay-evidence-topic-pack.yml
+++ b/.github/workflows/lattice-replay-evidence-topic-pack.yml
@@ -1,0 +1,27 @@
+name: lattice-replay-evidence-topic-pack
+
+on:
+  pull_request:
+    paths:
+      - "packs/lattice-data-governai/replay-evidence-topic-pack.v0.1.json"
+      - "tools/validate_lattice_replay_evidence_topic_pack.py"
+      - ".github/workflows/lattice-replay-evidence-topic-pack.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-lattice-replay-evidence-topic-pack:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Validate Lattice replay evidence topic pack
+        run: python tools/validate_lattice_replay_evidence_topic_pack.py

--- a/packs/lattice-data-governai/replay-evidence-topic-pack.v0.1.json
+++ b/packs/lattice-data-governai/replay-evidence-topic-pack.v0.1.json
@@ -1,0 +1,66 @@
+{
+  "apiVersion": "slash-topics.socioprophet.dev/v1",
+  "kind": "ReplayEvidenceTopicPack",
+  "metadata": {
+    "name": "lattice-replay-evidence",
+    "version": "0.1.0",
+    "description": "Slash Topics classifications for Lattice replay evidence bundles, lineage receipts, metrics artifacts, and replay command refs."
+  },
+  "spec": {
+    "publicSurfaceRef": "slash-topic://lattice/data-governai/replay-evidence",
+    "parentTopicPackRef": "slash-topics://packs/lattice-data-governai@0.1.0",
+    "runtimeProfileTopicPackRef": "slash-topics://packs/lattice-data-governai/runtime-profiles@0.1.0",
+    "runtimeAliasRef": "slash-topics://runtime/membranes/lattice-data-governai-admission@0.1.0",
+    "compatibilityRef": "newhope://membranes/lattice-data-governai-admission@0.1.0",
+    "memoryProfileRef": "memory-mesh://profiles/slash-topic-scoped-lattice-data-governai@0.1.0",
+    "sourceRefs": {
+      "mlopsReplayEvidencePr": "SocioProphet/prophet-platform-fabric-mlops-ts-suite#35",
+      "sherlockReplayEvidencePr": "SocioProphet/sherlock-search#33",
+      "demoReadinessTopologyPr": "SocioProphet/sociosphere#246",
+      "demoCommandBundlePr": "SocioProphet/cloudshell-fog#32"
+    },
+    "assetClassifications": [
+      {
+        "assetKind": "replay-evidence-bundle",
+        "topic": "/lattice/mlops/replay-evidence-bundle",
+        "scope": "mlops-replay-governance",
+        "governancePosture": "replay-evidence-required-for-demo-path",
+        "requiredRefs": ["policyRef", "evidenceCorrelationId", "runtimeRefs", "artifactRefs", "lineageReceiptRefs", "replayCommandRefs"],
+        "consumerSurfaces": ["sherlock-search", "policy-fabric", "agentplane", "cloudshell-fog", "new-hope"]
+      },
+      {
+        "assetKind": "lineage-receipt",
+        "topic": "/lattice/mlops/lineage-receipt",
+        "scope": "replayable-lineage",
+        "governancePosture": "lineage-receipt-required-for-replay",
+        "requiredRefs": ["lineageRunRef", "jobRef", "runtimeRef", "inputDigestRefs", "outputDigestRefs", "evidenceRef"],
+        "consumerSurfaces": ["sherlock-search", "policy-fabric", "agentplane", "new-hope"]
+      },
+      {
+        "assetKind": "metric-expectation",
+        "topic": "/lattice/mlops/metric-expectation",
+        "scope": "replayable-metrics",
+        "governancePosture": "expected-metrics-required-for-demo-readiness",
+        "requiredRefs": ["metricName", "runtimeRef", "artifactRef", "evidenceRef"],
+        "consumerSurfaces": ["sherlock-search", "policy-fabric", "lattice-studio"]
+      }
+    ],
+    "replayEvidenceBundle": {
+      "assetRef": "urn:srcos:evidence-bundle:lattice-governed-execution-0001",
+      "runtimeRefs": ["runtime-asset:prophet-ray-ml:0.1.0", "runtime-asset:prophet-beam-dataops:0.1.0"],
+      "artifactRefs": ["urn:srcos:artifact:community_truth_demo_ray_metrics", "urn:srcos:artifact:community_truth_demo_beam_quality", "urn:srcos:model:community_truth_demo_candidate"],
+      "lineageReceiptRefs": ["urn:srcos:lineage-receipt:ray-community-truth-demo-0001", "urn:srcos:lineage-receipt:beam-community-truth-demo-0001"],
+      "metricNames": ["factuality_f1", "grounding_precision", "training_records", "quality_completeness", "annotation_coverage", "duplicate_rate"],
+      "replayCommandRefs": ["/lattice mlops ray run community_truth_demo --runtime prophet-ray-ml --dry-run", "/lattice dataops beam run community_truth_demo --runtime prophet-beam-dataops --dry-run"],
+      "safety": {"network": "none", "secrets": "none", "hostMutation": false}
+    },
+    "routingRules": {
+      "publicSurface": "slash-topics",
+      "runtimeSubstrate": "new-hope",
+      "mustNotBypassPolicyFabric": true,
+      "mustNotRedefinePlatformAssetRecord": true,
+      "mustPreserveReplayEvidenceRefs": true,
+      "mustPreserveRuntimeAssetRefs": true
+    }
+  }
+}

--- a/tools/validate_lattice_replay_evidence_topic_pack.py
+++ b/tools/validate_lattice_replay_evidence_topic_pack.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Validate Lattice replay evidence Slash Topics pack."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+PACK = ROOT / "packs" / "lattice-data-governai" / "replay-evidence-topic-pack.v0.1.json"
+RAY = "runtime-asset:prophet-ray-ml:0.1.0"
+BEAM = "runtime-asset:prophet-beam-dataops:0.1.0"
+REQUIRED_ASSET_KINDS = {"replay-evidence-bundle", "lineage-receipt", "metric-expectation"}
+REQUIRED_ARTIFACTS = {
+    "urn:srcos:artifact:community_truth_demo_ray_metrics",
+    "urn:srcos:artifact:community_truth_demo_beam_quality",
+    "urn:srcos:model:community_truth_demo_candidate",
+}
+REQUIRED_RECEIPTS = {
+    "urn:srcos:lineage-receipt:ray-community-truth-demo-0001",
+    "urn:srcos:lineage-receipt:beam-community-truth-demo-0001",
+}
+REQUIRED_METRICS = {
+    "factuality_f1",
+    "grounding_precision",
+    "training_records",
+    "quality_completeness",
+    "annotation_coverage",
+    "duplicate_rate",
+}
+REQUIRED_COMMANDS = {
+    "/lattice mlops ray run community_truth_demo --runtime prophet-ray-ml --dry-run",
+    "/lattice dataops beam run community_truth_demo --runtime prophet-beam-dataops --dry-run",
+}
+REQUIRED_SOURCE_REFS = {
+    "mlopsReplayEvidencePr",
+    "sherlockReplayEvidencePr",
+    "demoReadinessTopologyPr",
+    "demoCommandBundlePr",
+}
+
+
+def fail(message: str) -> int:
+    print(f"ERR: {message}", file=sys.stderr)
+    return 1
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def require_str(mapping: dict[str, Any], key: str) -> str:
+    value = mapping.get(key)
+    require(isinstance(value, str) and bool(value), f"{key} must be non-empty string")
+    return value
+
+
+def require_list(mapping: dict[str, Any], key: str) -> list[Any]:
+    value = mapping.get(key)
+    require(isinstance(value, list) and value, f"{key} must be non-empty list")
+    return value
+
+
+def main() -> int:
+    if not PACK.exists():
+        return fail(f"missing {PACK}")
+    try:
+        data = json.loads(PACK.read_text(encoding="utf-8"))
+        require(data.get("apiVersion") == "slash-topics.socioprophet.dev/v1", "apiVersion mismatch")
+        require(data.get("kind") == "ReplayEvidenceTopicPack", "kind mismatch")
+        metadata = data.get("metadata")
+        require(isinstance(metadata, dict), "metadata must be object")
+        require(metadata.get("name") == "lattice-replay-evidence", "metadata.name mismatch")
+        spec = data.get("spec")
+        require(isinstance(spec, dict), "spec must be object")
+        require(require_str(spec, "publicSurfaceRef") == "slash-topic://lattice/data-governai/replay-evidence", "publicSurfaceRef mismatch")
+        require(require_str(spec, "parentTopicPackRef") == "slash-topics://packs/lattice-data-governai@0.1.0", "parentTopicPackRef mismatch")
+        require(require_str(spec, "compatibilityRef").startswith("newhope://"), "compatibilityRef must be New Hope ref")
+        source_refs = spec.get("sourceRefs")
+        require(isinstance(source_refs, dict), "sourceRefs must be object")
+        missing = sorted(REQUIRED_SOURCE_REFS - set(source_refs))
+        require(not missing, f"missing sourceRefs: {missing}")
+
+        classifications = require_list(spec, "assetClassifications")
+        kinds = set()
+        for item in classifications:
+            require(isinstance(item, dict), "classification must be object")
+            kind = require_str(item, "assetKind")
+            kinds.add(kind)
+            require(kind in REQUIRED_ASSET_KINDS, f"unexpected assetKind {kind}")
+            require(require_str(item, "topic").startswith("/lattice/mlops/"), "topic must be /lattice/mlops/*")
+            require_list(item, "requiredRefs")
+            surfaces = set(require_list(item, "consumerSurfaces"))
+            require("sherlock-search" in surfaces, f"{kind} must route to Sherlock")
+            require("policy-fabric" in surfaces, f"{kind} must route to Policy Fabric")
+        require(kinds == REQUIRED_ASSET_KINDS, f"asset kind coverage mismatch: {sorted(kinds)}")
+
+        bundle = spec.get("replayEvidenceBundle")
+        require(isinstance(bundle, dict), "replayEvidenceBundle must be object")
+        require(bundle.get("assetRef") == "urn:srcos:evidence-bundle:lattice-governed-execution-0001", "assetRef mismatch")
+        require(set(require_list(bundle, "runtimeRefs")) == {RAY, BEAM}, "runtimeRefs mismatch")
+        require(REQUIRED_ARTIFACTS <= set(require_list(bundle, "artifactRefs")), "artifactRefs incomplete")
+        require(REQUIRED_RECEIPTS <= set(require_list(bundle, "lineageReceiptRefs")), "lineageReceiptRefs incomplete")
+        require(REQUIRED_METRICS <= set(require_list(bundle, "metricNames")), "metricNames incomplete")
+        require(REQUIRED_COMMANDS <= set(require_list(bundle, "replayCommandRefs")), "replayCommandRefs incomplete")
+        safety = bundle.get("safety")
+        require(isinstance(safety, dict), "safety must be object")
+        require(safety.get("network") == "none", "network must be none")
+        require(safety.get("secrets") == "none", "secrets must be none")
+        require(safety.get("hostMutation") is False, "hostMutation must be false")
+
+        rules = spec.get("routingRules")
+        require(isinstance(rules, dict), "routingRules must be object")
+        require(rules.get("publicSurface") == "slash-topics", "publicSurface mismatch")
+        require(rules.get("runtimeSubstrate") == "new-hope", "runtimeSubstrate mismatch")
+        require(rules.get("mustNotBypassPolicyFabric") is True, "mustNotBypassPolicyFabric must be true")
+        require(rules.get("mustNotRedefinePlatformAssetRecord") is True, "mustNotRedefinePlatformAssetRecord must be true")
+        require(rules.get("mustPreserveReplayEvidenceRefs") is True, "mustPreserveReplayEvidenceRefs must be true")
+        require(rules.get("mustPreserveRuntimeAssetRefs") is True, "mustPreserveRuntimeAssetRefs must be true")
+    except Exception as exc:  # noqa: BLE001
+        return fail(str(exc))
+    print(f"PASS {PACK}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds Slash Topics classification for the Lattice replayable Ray/Beam evidence bundle.

## Adds

- `packs/lattice-data-governai/replay-evidence-topic-pack.v0.1.json`
- `tools/validate_lattice_replay_evidence_topic_pack.py`
- `.github/workflows/lattice-replay-evidence-topic-pack.yml`

## Coverage

Classifies replay evidence bundles, lineage receipts, and metric expectations with required runtime refs, artifact refs, lineage receipt refs, metric names, replay commands, and safety constraints.

## Validation

Expected:

```bash
python tools/validate_lattice_replay_evidence_topic_pack.py
```

## Tracking

Follows SocioProphet/prophet-platform-fabric-mlops-ts-suite#35 and SocioProphet/sherlock-search#33.